### PR TITLE
Add unused attribute

### DIFF
--- a/ViewDeck/IIViewDeckController.mm
+++ b/ViewDeck/IIViewDeckController.mm
@@ -227,7 +227,7 @@ II_DELEGATE_PROXY(IIViewDeckControllerDelegate);
 
 #pragma mark - Managing Transitions
 
-static inline BOOL IIIsAllowedTransition(IIViewDeckSide fromSide, IIViewDeckSide toSide) {
+__unused static inline BOOL IIIsAllowedTransition(IIViewDeckSide fromSide, IIViewDeckSide toSide) {
     return (fromSide == toSide) || (IIViewDeckSideIsValid(fromSide) && !IIViewDeckSideIsValid(toSide)) || (!IIViewDeckSideIsValid(fromSide) && IIViewDeckSideIsValid(toSide));
 }
 


### PR DESCRIPTION
When archived, unused function 'IIIsAllowedTransition',
because of use only NSAssert.

refs #557